### PR TITLE
Fixes several issues in the new AST term structures

### DIFF
--- a/key.core/src/main/java/de/uka/ilkd/key/java/Services.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/java/Services.java
@@ -147,7 +147,6 @@ public class Services implements TermServices {
         return result;
     }
 
-
     /**
      * Returns the TypeConverter associated with this Services object.
      */

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/NamespaceSet.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/NamespaceSet.java
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: GPL-2.0-only */
 package de.uka.ilkd.key.logic;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import de.uka.ilkd.key.java.JavaProgramElement;
@@ -23,8 +22,6 @@ public class NamespaceSet {
     private Namespace<QuantifiableVariable> varNS = new Namespace<>();
     private Namespace<IProgramVariable> progVarNS = new Namespace<>();
     // TODO: Operators should not be local to goals
-    private Map<Pair<Modality.JavaModalityKind, JavaProgramElement>, Modality> operators =
-        new HashMap<>();
     private Namespace<Function> funcNS = new Namespace<>();
     private Namespace<RuleSet> ruleSetNS = new Namespace<>();
     private Namespace<Sort> sortNS = new Namespace<>();
@@ -34,8 +31,7 @@ public class NamespaceSet {
     }
 
     public NamespaceSet(Namespace<QuantifiableVariable> varNS,
-            Map<Pair<Modality.JavaModalityKind, JavaProgramElement>, Modality> operators,
-            Namespace<Function> funcNS,
+                        Namespace<Function> funcNS,
             Namespace<Sort> sortNS, Namespace<RuleSet> ruleSetNS, Namespace<Choice> choiceNS,
             Namespace<IProgramVariable> programVarNS) {
         this.varNS = varNS;
@@ -47,13 +43,13 @@ public class NamespaceSet {
     }
 
     public NamespaceSet copy() {
-        return new NamespaceSet(variables().copy(), new HashMap<>(operators()), functions().copy(),
+        return new NamespaceSet(variables().copy(), functions().copy(),
             sorts().copy(),
             ruleSets().copy(), choices().copy(), programVariables().copy());
     }
 
     public NamespaceSet shallowCopy() {
-        return new NamespaceSet(variables(), operators(), functions(), sorts(), ruleSets(),
+        return new NamespaceSet(variables(), functions(), sorts(), ruleSets(),
             choices(),
             programVariables());
     }
@@ -61,7 +57,7 @@ public class NamespaceSet {
     // TODO MU: Rename into sth with wrap or similar
     public NamespaceSet copyWithParent() {
         return new NamespaceSet(new Namespace<>(variables()),
-            operators(), new Namespace<>(functions()), new Namespace<>(sorts()),
+                new Namespace<>(functions()), new Namespace<>(sorts()),
             new Namespace<>(ruleSets()), new Namespace<>(choices()),
             new Namespace<>(programVariables()));
     }
@@ -80,15 +76,6 @@ public class NamespaceSet {
 
     public void setProgramVariables(Namespace<IProgramVariable> progVarNS) {
         this.progVarNS = progVarNS;
-    }
-
-    public Map<Pair<Modality.JavaModalityKind, JavaProgramElement>, Modality> operators() {
-        return operators;
-    }
-
-    public void setOperators(
-            Map<Pair<Modality.JavaModalityKind, JavaProgramElement>, Modality> operators) {
-        this.operators = operators;
     }
 
     public Namespace<Function> functions() {
@@ -218,12 +205,12 @@ public class NamespaceSet {
 
     // create a namespace
     public NamespaceSet simplify() {
-        return new NamespaceSet(varNS.simplify(), operators, funcNS.simplify(), sortNS.simplify(),
+        return new NamespaceSet(varNS.simplify(), funcNS.simplify(), sortNS.simplify(),
             ruleSetNS.simplify(), choiceNS.simplify(), progVarNS.simplify());
     }
 
     public NamespaceSet getCompression() {
-        return new NamespaceSet(varNS.compress(), operators, funcNS.compress(), sortNS.compress(),
+        return new NamespaceSet(varNS.compress(), funcNS.compress(), sortNS.compress(),
             ruleSetNS.compress(), choiceNS.compress(), progVarNS.compress());
     }
 
@@ -234,7 +221,7 @@ public class NamespaceSet {
     }
 
     public NamespaceSet getParent() {
-        return new NamespaceSet(varNS.parent(), operators, funcNS.parent(), sortNS.parent(),
+        return new NamespaceSet(varNS.parent(), funcNS.parent(), sortNS.parent(),
             ruleSetNS.parent(), choiceNS.parent(), progVarNS.parent());
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/TermBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/TermBuilder.java
@@ -423,12 +423,12 @@ public class TermBuilder {
 //    }
 
     public Term prog(Modality.JavaModalityKind modKind, JavaBlock jb, Term t) {
-        return tf.createTerm(modality(modKind, jb), new Term[] { t }, null, jb);
+        return tf.createTerm(Modality.modality(modKind, jb), new Term[] { t }, null, jb);
     }
 
     public Term prog(Modality.JavaModalityKind modKind, JavaBlock jb, Term t,
             ImmutableArray<TermLabel> labels) {
-        return tf.createTerm(modality(modKind, jb), new Term[] { t }, null, jb, labels);
+        return tf.createTerm(Modality.modality(modKind, jb), new Term[] { t }, null, jb, labels);
     }
 
     public Term box(JavaBlock jb, Term t) {
@@ -437,17 +437,6 @@ public class TermBuilder {
 
     public Term dia(JavaBlock jb, Term t) {
         return prog(Modality.JavaModalityKind.DIA, jb, t);
-    }
-
-    // TODO: move?
-    public Modality modality(Modality.JavaModalityKind kind, JavaBlock jb) {
-        var pair = new Pair<>(kind, jb.program());
-        Modality mod = services.getNamespaces().operators().get(pair);
-        if (mod == null) {
-            mod = new Modality(jb, kind);
-            services.getNamespaces().operators().put(pair, mod);
-        }
-        return mod;
     }
 
     public Term ife(Term cond, Term _then, Term _else) {
@@ -1706,7 +1695,7 @@ public class TermBuilder {
 
             for (TermLabel newLabel : labels) {
                 for (TermLabel oldLabel : newLabelList) {
-                    if (oldLabel.getClass().equals(newLabel.getClass())) {
+                    if (oldLabel.getClass() == newLabel.getClass()) {
                         newLabelList.remove(oldLabel);
                         break;
                     }

--- a/key.core/src/main/java/de/uka/ilkd/key/logic/op/Modality.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/logic/op/Modality.java
@@ -6,6 +6,7 @@ package de.uka.ilkd.key.logic.op;
 import java.util.HashMap;
 import java.util.Map;
 
+import de.uka.ilkd.key.java.JavaProgramElement;
 import de.uka.ilkd.key.ldt.JavaDLTheory;
 import de.uka.ilkd.key.logic.JavaBlock;
 import de.uka.ilkd.key.logic.Term;
@@ -15,12 +16,37 @@ import de.uka.ilkd.key.logic.sort.Sort;
 
 import org.key_project.logic.Name;
 import org.key_project.logic.Program;
+import org.key_project.util.collection.Pair;
 
 /**
  * This class is used to represent a dynamic logic modality like diamond and box (but also
  * extensions of DL like preserves and throughout are possible in the future).
  */
 public class Modality extends org.key_project.logic.op.Modality<Sort> implements Operator {
+    /*
+       keeps track of created modalities
+     */
+    private static Map<Pair<JavaModalityKind, JavaProgramElement>, Modality> operators =
+            new HashMap<>();
+
+
+    /**
+     * Returns the knownm modalities
+     */
+    public static Map<Pair<JavaModalityKind, JavaProgramElement>, Modality> operators() {
+        return operators;
+    }
+
+    public static Modality modality(Modality.JavaModalityKind kind, JavaBlock jb) {
+        var pair = new Pair<>(kind, jb.program());
+        Modality mod = Modality.operators().get(pair);
+        if (mod == null) {
+            mod = new Modality(jb, kind);
+            Modality.operators().put(pair, mod);
+        }
+        return mod;
+    }
+
     /**
      * creates a modal operator with the given name
      *
@@ -142,7 +168,6 @@ public class Modality extends org.key_project.logic.op.Modality<Sort> implements
          */
         public static final JavaModalityKind TOUT_TRANSACTION =
             new JavaModalityKind(new Name("throughout_transaction"));
-        public static final JavaModalityKind MOD_SV = new JavaModalityKind(new Name("mod_sv"));
 
         public JavaModalityKind(Name name) {
             super(name);

--- a/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/nparser/builder/ExpressionBuilder.java
@@ -1151,9 +1151,10 @@ public class ExpressionBuilder extends DefaultBuilder {
              * "No schema elements allowed outside taclet declarations (" + sjb.opName + ")"); }
              */
             Modality.JavaModalityKind kind = (Modality.JavaModalityKind) schemaVariables().lookup(new Name(sjb.opName));
-            op = getServices().getTermBuilder().modality(kind, sjb.javaBlock);
+            op = Modality.modality(kind, sjb.javaBlock);
         } else {
-            op = getServices().getTermBuilder().modality(Modality.JavaModalityKind.getKind(sjb.opName), sjb.javaBlock);
+            Modality.JavaModalityKind kind = Modality.JavaModalityKind.getKind(sjb.opName);
+            op = Modality.modality(kind, sjb.javaBlock);
         }
         if (op == null) {
             semanticError(ctx, "Unknown modal operator: " + sjb.opName);

--- a/key.core/src/main/java/de/uka/ilkd/key/parser/DefaultTermParser.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/parser/DefaultTermParser.java
@@ -5,9 +5,7 @@ package de.uka.ilkd.key.parser;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.util.Map;
 
-import de.uka.ilkd.key.java.JavaProgramElement;
 import de.uka.ilkd.key.java.Services;
 import de.uka.ilkd.key.logic.Namespace;
 import de.uka.ilkd.key.logic.NamespaceSet;
@@ -15,13 +13,10 @@ import de.uka.ilkd.key.logic.Sequent;
 import de.uka.ilkd.key.logic.Term;
 import de.uka.ilkd.key.logic.op.Function;
 import de.uka.ilkd.key.logic.op.IProgramVariable;
-import de.uka.ilkd.key.logic.op.Modality;
 import de.uka.ilkd.key.logic.op.QuantifiableVariable;
 import de.uka.ilkd.key.logic.sort.Sort;
 import de.uka.ilkd.key.nparser.KeyIO;
 import de.uka.ilkd.key.pp.AbbrevMap;
-
-import org.key_project.util.collection.Pair;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.RecognitionException;
@@ -42,18 +37,16 @@ public final class DefaultTermParser {
      * ensures, that the term has the specified sort.
      *
      * @param sort The expected sort of the term.
-     * @param op_ns
      * @return The parsed term of the specified sort.
      * @throws ParserException The method throws a ParserException, if the input could not be parsed
-     *         correctly or the term has an invalid sort.
+     *                         correctly or the term has an invalid sort.
      */
     public Term parse(Reader in, Sort sort, Services services,
             Namespace<QuantifiableVariable> var_ns,
-            Map<Pair<Modality.JavaModalityKind, JavaProgramElement>, Modality> op_ns,
-            Namespace<Function> func_ns,
+                      Namespace<Function> func_ns,
             Namespace<Sort> sort_ns, Namespace<IProgramVariable> progVar_ns, AbbrevMap scm)
             throws ParserException {
-        return parse(in, sort, services, new NamespaceSet(var_ns, op_ns, func_ns, sort_ns,
+        return parse(in, sort, services, new NamespaceSet(var_ns, func_ns, sort_ns,
             new Namespace<>(), new Namespace<>(), progVar_ns), scm);
     }
 

--- a/key.core/src/main/java/de/uka/ilkd/key/pp/LogicPrinter.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/pp/LogicPrinter.java
@@ -1667,7 +1667,8 @@ public class LogicPrinter {
                     for (int i = 0; i < phi.arity(); i++) {
                         ta[i] = phi.sub(i);
                     }
-                    Modality m = services.getTermBuilder().modality(mod.kind(), mod.program());
+                    JavaBlock jb1 = mod.program();
+                    Modality m = Modality.modality(mod.kind(), jb1);
                     Term term = services.getTermFactory().createTerm(m, ta,
                         phi.boundVars(), phi.javaBlock());
                     notationInfo.getNotation(m).print(term, this);

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/init/FunctionalBlockContractPO.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/init/FunctionalBlockContractPO.java
@@ -468,11 +468,10 @@ public class FunctionalBlockContractPO extends AbstractPO implements ContractPO 
         final KeYJavaType kjt = getCalleeKeYJavaType();
         final TypeRef typeRef = new TypeRef(new ProgramElementName(kjt.getName()), 0, selfVar, kjt);
         final ExecutionContext ec = new ExecutionContext(typeRef, getProgramMethod(), selfVar);
-        // TODO (DD): HACK
         final Instantiation inst =
             new Instantiation(tb.skip(), tb.tt(),
-                new Modality(JavaBlock.createJavaBlock(new StatementBlock()),
-                    contract.getModalityKind()),
+                Modality.modality(contract.getModalityKind(),
+                        JavaBlock.createJavaBlock(new StatementBlock())),
                 selfTerm, block, ec);
         return new GoalsConfigurator(null, new TermLabelState(), inst,
             contract.getAuxiliaryContract().getLabels(), variables, null, services, null);

--- a/key.core/src/main/java/de/uka/ilkd/key/proof/io/IntermediateProofReplayer.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/proof/io/IntermediateProofReplayer.java
@@ -940,7 +940,7 @@ public class IntermediateProofReplayer {
             Namespace<IProgramVariable> progVarNS, Namespace<Function> functNS) {
         try {
             return new DefaultTermParser().parse(new StringReader(value), null, proof.getServices(),
-                varNS, proof.getNamespaces().operators(), functNS, proof.getNamespaces().sorts(),
+                varNS, functNS, proof.getNamespaces().sorts(),
                 progVarNS, new AbbrevMap());
         } catch (ParserException e) {
             throw new RuntimeException(

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/SyntacticalReplaceVisitor.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/SyntacticalReplaceVisitor.java
@@ -219,7 +219,7 @@ public class SyntacticalReplaceVisitor extends DefaultVisitor {
             kind = (Modality.JavaModalityKind) svInst.getInstantiation(op.kind());
         }
         if (jb != op.program() || kind != op.kind()) {
-            return tb.modality(kind, jb);
+            return Modality.modality(kind, jb);
         }
         return op;
     }

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/conditions/HasLoopInvariantCondition.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/conditions/HasLoopInvariantCondition.java
@@ -59,11 +59,11 @@ public class HasLoopInvariantCondition implements VariableCondition {
                 .map(methodFrame -> MiscTools.getSelfTerm(methodFrame, services)).orElse(null);
 
         // TODO: handle exception!
-        final Modality modality = (Modality) svInst.getInstantiation(modalitySV);
+        final Modality.JavaModalityKind modalityKind =
+                (Modality.JavaModalityKind) svInst.getInstantiation(modalitySV);
 
         boolean hasInv = false;
-        for (final LocationVariable heap : MiscTools.applicableHeapContexts(modality.kind(),
-            services)) {
+        for (final LocationVariable heap : MiscTools.applicableHeapContexts(modalityKind, services)) {
             final Optional<Term> maybeInvInst = Optional.ofNullable(
                 loopSpec.getInvariant(heap, selfTerm, loopSpec.getInternalAtPres(), services));
             final Optional<Term> maybeFreeInvInst = Optional.ofNullable(

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/conditions/LoopFreeInvariantCondition.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/conditions/LoopFreeInvariantCondition.java
@@ -68,10 +68,10 @@ public class LoopFreeInvariantCondition implements VariableCondition {
                 .map(methodFrame -> MiscTools.getSelfTerm(methodFrame, services)).orElse(null);
 
         // TODO: Handle exception?!
-        final Modality modality = (Modality) svInst.getInstantiation(modalitySV);
+        final Modality.JavaModalityKind modalityKind = (Modality.JavaModalityKind) svInst.getInstantiation(modalitySV);
 
         Term freeInvInst = tb.tt();
-        for (final LocationVariable heap : MiscTools.applicableHeapContexts(modality.kind(),
+        for (final LocationVariable heap : MiscTools.applicableHeapContexts(modalityKind,
             services)) {
             final Term currentFreeInvInst = freeInvInst;
 

--- a/key.core/src/main/java/de/uka/ilkd/key/rule/conditions/LoopInvariantCondition.java
+++ b/key.core/src/main/java/de/uka/ilkd/key/rule/conditions/LoopInvariantCondition.java
@@ -68,10 +68,11 @@ public class LoopInvariantCondition implements VariableCondition {
                 .map(methodFrame -> MiscTools.getSelfTerm(methodFrame, services)).orElse(null);
 
         // TODO: handle exception
-        final Modality modality = (Modality) svInst.getInstantiation(modalitySV);
+        final Modality.JavaModalityKind modalityKind =
+                (Modality.JavaModalityKind) svInst.getInstantiation(modalitySV);
 
         Term invInst = tb.tt();
-        for (final LocationVariable heap : MiscTools.applicableHeapContexts(modality.kind(),
+        for (final LocationVariable heap : MiscTools.applicableHeapContexts(modalityKind,
             services)) {
             final Term currentInvInst = invInst;
 

--- a/key.core/src/test/java/de/uka/ilkd/key/logic/TestTerm.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/logic/TestTerm.java
@@ -194,7 +194,7 @@ public class TestTerm {
         Term noJBWithChild = tf.createTerm(Junctor.NOT, noJB);
         JavaBlock javaBlock =
             JavaBlock.createJavaBlock(new StatementBlock(new LocalVariableDeclaration()));
-        Term withJB = tf.createTerm(tb.modality(Modality.JavaModalityKind.DIA, javaBlock), new ImmutableArray<>(noJB), null, javaBlock);
+        Term withJB = tf.createTerm(Modality.modality(Modality.JavaModalityKind.DIA, javaBlock), new ImmutableArray<>(noJB), null, javaBlock);
         Term withJBChild = tf.createTerm(Junctor.NOT, withJB);
         Term withJBChildChild = tf.createTerm(Junctor.NOT, withJBChild);
         assertFalse(noJB.containsJavaBlockRecursive());

--- a/key.core/src/test/java/de/uka/ilkd/key/logic/TestTermFactory.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/logic/TestTermFactory.java
@@ -166,15 +166,15 @@ public class TestTermFactory {
     @Test
     public void testDiamondTerm() {
         JavaBlock jb = JavaBlock.EMPTY_JAVABLOCK;
-        Term t_dia_ryw = tf.createTerm(TB.modality(Modality.JavaModalityKind.DIA, jb), new Term[] { t2() }, null, jb);
-        assertEquals(t_dia_ryw, new TermImpl(TB.modality(Modality.JavaModalityKind.DIA, jb), new ImmutableArray<>(t2()), null, jb));
+        Term t_dia_ryw = tf.createTerm(Modality.modality(Modality.JavaModalityKind.DIA, jb), new Term[] { t2() }, null, jb);
+        assertEquals(t_dia_ryw, new TermImpl(Modality.modality(Modality.JavaModalityKind.DIA, jb), new ImmutableArray<>(t2()), null, jb));
     }
 
     @Test
     public void testBoxTerm() {
         JavaBlock jb = JavaBlock.EMPTY_JAVABLOCK;
-        Term t_dia_ryw = tf.createTerm(TB.modality(Modality.JavaModalityKind.BOX, jb), new ImmutableArray<>(t2()), null, jb);
-        assertEquals(t_dia_ryw, new TermImpl(TB.modality(Modality.JavaModalityKind.BOX, jb), new ImmutableArray<>(t2()), null, jb));
+        Term t_dia_ryw = tf.createTerm(Modality.modality(Modality.JavaModalityKind.BOX, jb), new ImmutableArray<>(t2()), null, jb);
+        assertEquals(t_dia_ryw, new TermImpl(Modality.modality(Modality.JavaModalityKind.BOX, jb), new ImmutableArray<>(t2()), null, jb));
     }
 
     @Test
@@ -319,7 +319,7 @@ public class TestTermFactory {
         Term noJBWithChild = tf.createTerm(Junctor.NOT, noJB);
         JavaBlock javaBlock =
             JavaBlock.createJavaBlock(new StatementBlock(new LocalVariableDeclaration()));
-        Term withJB = tf.createTerm(TB.modality(Modality.JavaModalityKind.DIA, javaBlock), new ImmutableArray<>(noJB), null, javaBlock);
+        Term withJB = tf.createTerm(Modality.modality(Modality.JavaModalityKind.DIA, javaBlock), new ImmutableArray<>(noJB), null, javaBlock);
         Term withJBChild = tf.createTerm(Junctor.NOT, withJB);
         Term withJBChildChild = tf.createTerm(Junctor.NOT, withJBChild);
         // Create Same terms again
@@ -328,7 +328,7 @@ public class TestTermFactory {
         JavaBlock javaBlockAgain =
             JavaBlock.createJavaBlock(new StatementBlock(new LocalVariableDeclaration()));
         Term withJBAgain =
-            tf.createTerm(TB.modality(Modality.JavaModalityKind.DIA, javaBlockAgain), new ImmutableArray<>(noJB), null, javaBlockAgain);
+            tf.createTerm(Modality.modality(Modality.JavaModalityKind.DIA, javaBlockAgain), new ImmutableArray<>(noJB), null, javaBlockAgain);
         Term withJBChildAgain = tf.createTerm(Junctor.NOT, withJB);
         Term withJBChildChildAgain = tf.createTerm(Junctor.NOT, withJBChild);
         // Test caching

--- a/key.core/src/test/java/de/uka/ilkd/key/rule/TestSchemaModalOperators.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/rule/TestSchemaModalOperators.java
@@ -124,10 +124,10 @@ public class TestSchemaModalOperators {
             JavaDLTheory.FORMULA, modalities);
         Term tpost = TB.tf().createTerm(fsv);
 
-        Term find = TB.tf().createTerm(TB.modality((Modality.JavaModalityKind) osv, JavaBlock.EMPTY_JAVABLOCK), new Term[] { tpost }, null, JavaBlock.EMPTY_JAVABLOCK);
+        Term find = TB.tf().createTerm(Modality.modality((Modality.JavaModalityKind) osv, JavaBlock.EMPTY_JAVABLOCK), new Term[] { tpost }, null, JavaBlock.EMPTY_JAVABLOCK);
 
         Term replace =
-            TB.tf().createTerm(TB.modality((Modality.JavaModalityKind) osv, JavaBlock.EMPTY_JAVABLOCK), new Term[] { TB.tt() }, null, JavaBlock.EMPTY_JAVABLOCK);
+            TB.tf().createTerm(Modality.modality((Modality.JavaModalityKind) osv, JavaBlock.EMPTY_JAVABLOCK), new Term[] { TB.tt() }, null, JavaBlock.EMPTY_JAVABLOCK);
 
         rtb.setName(new Name("test_schema_modal1"));
         rtb.setFind(find);

--- a/key.core/src/test/java/de/uka/ilkd/key/strategy/quantifierHeuristics/TestTriggersSet.java
+++ b/key.core/src/test/java/de/uka/ilkd/key/strategy/quantifierHeuristics/TestTriggersSet.java
@@ -18,8 +18,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
@@ -193,13 +191,13 @@ public class TestTriggersSet {
         proof.setRoot(g.node());
         proof.add(g);
 
-        proof.setNamespaces(new NamespaceSet(variables, new HashMap<>(), functions, sorts, new Namespace<>(),
+        proof.setNamespaces(new NamespaceSet(variables, functions, sorts, new Namespace<>(),
             new Namespace<>(), new Namespace<>()));
 
     }
 
     private Term parseTerm(String termstr) {
-        return TacletForTests.parseTerm(termstr, new NamespaceSet(variables, new HashMap<>(), functions, sorts,
+        return TacletForTests.parseTerm(termstr, new NamespaceSet(variables, functions, sorts,
             new Namespace<>(), new Namespace<>(), new Namespace<>()));
     }
 


### PR DESCRIPTION
This PR fixes some bugs in the new term structure.

For the moment, I had to move the modalities in its static HashMap (no longer in NamespaceSet). 

Do not merge this PR yet. The branch https://github.com/Drodt/key/tree/fixedIssuesAndRebased
contains this fix and is rebase on the current KeY main branch. 

This fixes the remaining problems and we can at least prove BinarySearch, but still not RemoveDup.