### PR TITLE
More taclets in testrules,key

### DIFF
--- a/keyext.rusty_while/src/main/java/org/key_project/rusty/logic/SequentFormula.java
+++ b/keyext.rusty_while/src/main/java/org/key_project/rusty/logic/SequentFormula.java
@@ -24,4 +24,9 @@ public class SequentFormula {
     public Term formula() {
         return term;
     }
+
+    /** String representation */
+    public String toString() {
+        return term.toString();
+    }
 }

--- a/keyext.rusty_while/src/main/java/org/key_project/rusty/proof/Node.java
+++ b/keyext.rusty_while/src/main/java/org/key_project/rusty/proof/Node.java
@@ -45,4 +45,16 @@ public class Node {
         this(proof, seq);
         this.parent = parent;
     }
+
+    /**
+     * sets the sequent at this node
+     */
+    public void setSequent(Sequent seq) {
+        this.seq = seq;
+    }
+
+    /** returns the sequent of this node */
+    public Sequent sequent() {
+        return seq;
+    }
 }

--- a/keyext.rusty_while/src/main/java/org/key_project/rusty/rule/tacletbuilder/AntecSuccTacletGoalTemplate.java
+++ b/keyext.rusty_while/src/main/java/org/key_project/rusty/rule/tacletbuilder/AntecSuccTacletGoalTemplate.java
@@ -41,4 +41,12 @@ public class AntecSuccTacletGoalTemplate extends TacletGoalTemplate {
     public Sequent replaceWith() {
         return replaceWith;
     }
+
+    /** toString */
+    @Override
+    public String toString() {
+        String result = super.toString();
+        result += "\\replacewith(" + replaceWith() + ") ";
+        return result;
+    }
 }

--- a/keyext.rusty_while/src/main/java/org/key_project/rusty/rule/tacletbuilder/TacletGoalTemplate.java
+++ b/keyext.rusty_while/src/main/java/org/key_project/rusty/rule/tacletbuilder/TacletGoalTemplate.java
@@ -80,6 +80,10 @@ public class TacletGoalTemplate {
         return addedRules;
     }
 
+    public ImmutableSet<SchemaVariable> addedProgVars() {
+        return addedProgVars;
+    }
+
     /**
      * retrieves and returns all variables that are bound in the goal template
      *
@@ -104,5 +108,20 @@ public class TacletGoalTemplate {
 
     public String name() {
         return name;
+    }
+
+    @Override
+    public String toString() {
+        String result = "";
+        if (!sequent().isEmpty()) {
+            result += "\\add " + sequent() + " ";
+        }
+        if (!rules().isEmpty()) {
+            result += "\\addrules " + rules() + " ";
+        }
+        if (!addedProgVars().isEmpty()) {
+            result += "\\addprogvars " + addedProgVars() + " ";
+        }
+        return result;
     }
 }

--- a/keyext.rusty_while/src/test/java/org/key_project/rusty/BasicTest.java
+++ b/keyext.rusty_while/src/test/java/org/key_project/rusty/BasicTest.java
@@ -68,6 +68,9 @@ public class BasicTest {
         Sequent s = Sequent.createSuccSequent(succ);
         Proof p = new Proof("FirstProof", TacletForTests.initConfig());
         p.setRoot(new Node(p, s));
+
+        p.getRoot().sequent().succedent().getFirst().formula();
+        // continue manual proof like for example in TestApplyTaclet
     }
 
     @Test

--- a/keyext.rusty_while/src/test/resources/testcase/testrules.key
+++ b/keyext.rusty_while/src/test/resources/testcase/testrules.key
@@ -32,7 +32,7 @@
 
 \schemaVariables {
 
-	\formula b;
+	\formula b, c;
 
 } 
 
@@ -40,9 +40,30 @@
 \rules { 
 
   close_goal { \assumes (b ==>) \find (==> b) \closegoal };
+  close_by_false { \find (false ==>) \closegoal };
+  close_by_true  { \find (==> true) \closegoal };
   true_left    { \find (true ==>) \replacewith(==>) };
   false_right  { \find (==> false) \replacewith(==>) };
 
+  not_left  { \find (! b ==>) \replacewith(==> b) };
+  not_right { \find (==> ! b) \replacewith(b ==>) };
 
+  imp_left  { \find (b -> c ==>) 
+		\replacewith(==> b); 
+                \replacewith(c ==>) };
+  imp_right { \find (==> b -> c) \replacewith(b ==> c) };
+
+
+  and_left  { \find (b & c ==>) \replacewith(b, c ==>) };
+  and_right { \find (==> b & c) \replacewith(==> b); \replacewith(==> c) };
+  or_left   { \find (b | c ==>) \replacewith(b ==>); \replacewith(c ==>) };
+  or_right  { \find (==> b | c) \replacewith(==> b, c) };
+  equiv_left   { \find (b <-> c ==>) 
+		      \replacewith(b, c ==>); 
+                      \replacewith(==> b, c) };
+  
+  equiv_right  { \find (==> b <-> c) 
+		      \replacewith(b ==> c);
+                      \replacewith(c ==> b) };
 
 } 


### PR DESCRIPTION
<!--
Thanks for submitting this pull request for KeY.
Since the project has a strict review policy, please make the
reviewer's job easier by providing the necessary information
in the text below. The comments can be deleted, but may also 
remain since they will be invisible when showing the PR.
-->

## Intended Change

<!-- Please give a brief description of what behaviour changes and 
     why it should be changed. -->

I have implemented a few `toString()` methods that help when trying to look at the created taclets in the debugger and added more basic taclets in `testrules.key`.
All taclets in `testrules.key` get parsed in `BasicTest` and are available in `TacletForTests#initConfig`.
I have checked that the parsed taclets look identical to the same basic taclets parsed in key.core, with the only exception being that the field `boundVariables` of the taclets is `null` in `BasicTest` and not an empty list.
As we have not yet dealt with quantification, I guess this is to be expected.


The contributions within this pull request are licensed under GPLv2 (only) for inclusion in KeY.
